### PR TITLE
#74 💵 fix: 평가손익 계산 오류 수정

### DIFF
--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -24,7 +24,7 @@ const page: React.FC = () => {
 
       <div className="bg-yellow-100 m-auto flex justify-center items-center">
         <Trading currentPrice={currentPrice}></Trading>
-        <MyAssets currentPrice={currentPrice}></MyAssets>
+        <MyAssets />
       </div>
     </div>
   );

--- a/src/components/exchange/MyAssets.tsx
+++ b/src/components/exchange/MyAssets.tsx
@@ -4,11 +4,10 @@ import { useRecoilValue } from "recoil";
 import { userUidAssetData } from "@/atoms/atom";
 
 import MyAssetCoinList from "./MyAssetCoinList";
-import { IcurrentPrice } from "@/interface/interface";
 
 import { RiBitCoinFill } from "react-icons/ri";
 
-const MyAssets = ({ currentPrice }: { currentPrice: IcurrentPrice }) => {
+const MyAssets = () => {
   const userAssetData = useRecoilValue(userUidAssetData);
 
   let myCash: number = 0;
@@ -49,7 +48,7 @@ const MyAssets = ({ currentPrice }: { currentPrice: IcurrentPrice }) => {
               <p className="w-[30%] flex justify-center">수익률</p>
             </div>
           </figure>
-          <MyAssetCoinList currentPrice={currentPrice} />
+          <MyAssetCoinList />
         </article>
       </section>
     </div>


### PR DESCRIPTION
## 요약
#74 평가손익 계산 오류 수정
## 내용
- [x] userAssetData에서 코인 이름 추출
- [x] 추출된 코인 이름으로 업비트 API에서 각 코인 별 현재가 추출
- [x] 현재가를 이용하여 각 코인 별 평가손익 계산