### PR TITLE
#103 💎 style : 매매페이지 반응형 css

### DIFF
--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -17,13 +17,13 @@ const page: React.FC = () => {
   const className = "pr-3 pt-4";
 
   return (
-    <div className="w-screen h-screen bg-yellow-100 justify-center flex items-center flex-col ">
+    <div className="w-screen h-screen bg-yellow-100 justify-center flex items-center flex-col max-[910px]:flex-col max-[910px]:h-[1150px]">
       <div className="flex flex-row w-screen justify-self-start justify-between">
         <Logo className={className2} />
         <LogInOutButton className={className} />
       </div>
 
-      <div className="bg-yellow-100 m-auto flex justify-center items-center">
+      <div className="w-screen h-screen bg-yellow-100 m-auto flex justify-center items-center max-[910px]:flex-col">
         <Trading currentPrice={currentPrice}></Trading>
         <MyAssets />
       </div>

--- a/src/components/exchange/MyAssetCoinList.tsx
+++ b/src/components/exchange/MyAssetCoinList.tsx
@@ -85,7 +85,7 @@ const MyAssetCoinList = () => {
           return (
             <div key={name}>
               <figure
-                className="h-12 px-2.5 pt-1 border-b border-grey"
+                className="h-12 px-2.5 pt-1 border-b border-grey hover:cursor-pointer"
                 onClick={() => handleCoinListClick(index)}
               >
                 <div className="flex items-center">

--- a/src/components/exchange/MyAssets.tsx
+++ b/src/components/exchange/MyAssets.tsx
@@ -24,7 +24,7 @@ const MyAssets = () => {
 
   return (
     <div>
-      <section className="bg-yellow-200 w-[26rem] h-[30rem] rounded-xl border-white border-[3px] px-8 py-8 flex-col items-center ml-14">
+      <section className="bg-yellow-200 w-[26rem] h-[30rem] rounded-xl border-white border-[3px] px-8 py-8 flex-col items-center ml-14 max-[910px]:ml-0">
         <article className="bg-white h-[3.1rem] rounded-xl border-black-100 border-[3px] flex justify-around items-center pt-1.5 pb-2 text-black-100 text-lg font-semibold mb-7">
           보유자산
         </article>

--- a/src/components/exchange/Trading.tsx
+++ b/src/components/exchange/Trading.tsx
@@ -32,7 +32,7 @@ const Trading = ({ currentPrice }: { currentPrice: IcurrentPrice }) => {
     "bg-grey w-[10.3rem] h-[3rem] rounded-xl border-black-100 border-[3px] text-black-100 text-lg font-semibold";
 
   return (
-    <section className="bg-white w-[26rem] h-[30rem] rounded-xl border-black-100 border-[3px] px-8 py-8 flex-col items-center">
+    <section className="bg-white w-[26rem] h-[30rem] rounded-xl border-black-100 border-[3px] px-8 py-8 flex-col items-center max-[910px]:mb-8">
       <article className="border-black-100 flex items-center justify-between mb-4">
         <button
           className={`${isBuy ? `${isButtonClicked}` : `${isButtonUnClicked}`}`}
@@ -82,7 +82,7 @@ const Trading = ({ currentPrice }: { currentPrice: IcurrentPrice }) => {
           />
         </figure>
       </article>
-      <article className="bg-yellow-100 rounded-lg border-black-100 border-[3px] flex justify-around items-center mb-4 pt-1.5 pb-2 text-black-100 text-xs font-[Galmuri11] font-semibold">
+      <article className="bg-yellow-100 rounded-lg border-black-100 border-[3px] flex justify-around items-center mb-4 pt-2 pb-2 text-black-100 text-xs font-[Galmuri11] font-semibold">
         <button onClick={handleTotalOrderAmountPercent} id="10">
           10%
         </button>


### PR DESCRIPTION
## 요약
#103  매매페이지 반응형 css
## 내용
- [ ] 910px 이하부터 컴포넌트 세로로 배치