### PR TITLE
#134 💵 fix : 100% 매수 오류 수정

### DIFF
--- a/src/hooks/useTrading.ts
+++ b/src/hooks/useTrading.ts
@@ -128,13 +128,13 @@ const useTrading = ({ currentPrice }: { currentPrice: IcurrentPrice }) => {
 
     if (isBuy) setIsTotalOderAmountChanged(prev => !prev);
     if (isBuy && percent10)
-      setTotalOrderAmount(Math.ceil(myCash * 0.1).toString());
+      setTotalOrderAmount(Math.floor(myCash * 0.1).toString());
     if (isBuy && percent25)
-      setTotalOrderAmount(Math.ceil(myCash * 0.25).toString());
+      setTotalOrderAmount(Math.floor(myCash * 0.25).toString());
     if (isBuy && percent50)
-      setTotalOrderAmount(Math.ceil(myCash * 0.5).toString());
+      setTotalOrderAmount(Math.floor(myCash * 0.5).toString());
     if (isBuy && percent100)
-      setTotalOrderAmount(Math.ceil(myCash * 0.9995).toString());
+      setTotalOrderAmount(Math.floor(myCash * 0.9995).toString());
 
     if (isSell) setIsOrderQuantityChanged(prev => !prev);
     if (isSellWithCoin && percent10) {


### PR DESCRIPTION
## 요약
100% 매수 오류 수정
## 내용
- [x] 100% 버튼 클릭시, 수수료를 포함한 금액이 현금보다 큰 오류 수정 
